### PR TITLE
Move FT bucket labels to centre of their rows

### DIFF
--- a/dashboard_ui/config/dashboards/Vibration Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Vibration Monitoring/dashboard.json
@@ -299,7 +299,7 @@
           "show": true
         },
         "rowsFrame": {
-          "layout": "ge"
+          "layout": "unknown"
         },
         "tooltip": {
           "show": true,


### PR DESCRIPTION
The data for the 1 Hz fft result isn't for the 1-2 Hz range, it is around 1Hz itself.
In grafana language tick alignment bottom is described as `GE`, top is `LE` and middle is `unknown`...

Could bump version also for smoother upgrading but updating without rebuilding the whole repo is rare. 